### PR TITLE
fix: sidebar sizing and layout

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -30,7 +30,7 @@ export const Sidebar = () => {
             animate={{ x: 0 }}
             transition={{ duration: 0.2, ease: "linear" }}
             exit={{ x: -200 }}
-            className="px-6  z-[100] py-10 bg-neutral-100 lg:w-[14%] border-r border-neutral-200/[0.8] fixed lg:relative  h-screen left-0 lg:flex flex-col justify-between max-w-[14rem]"
+            className="px-6  z-[100] py-10 bg-neutral-100 max-w-[14rem] lg:w-fit border-r border-neutral-200/[0.8] fixed lg:relative  h-screen left-0 flex flex-col justify-between"
           >
             <div className="">
               <SidebarHeader />


### PR DESCRIPTION
## changes

- I made the `Sidebar` use a constant width instead of `14%` of parent width. 
  - This makes the sidebar content look better across different screen sizes
- I changes the `Sidebar` layout to always use `flex` so that the `Read Resume` button does not jump around and is always placed in a consistent place.

## before

https://github.com/manuarora700/sidefolio/assets/16091805/b37c5cd6-a3c2-456b-9c82-c8c8fafda4ab

## after

https://github.com/manuarora700/sidefolio/assets/16091805/4d60dc95-89cf-4213-a10a-6ca33c7dd20f

