### PR TITLE
fix resume mobile sidebar button

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -41,7 +41,7 @@ export const Sidebar = () => {
         )}
       </AnimatePresence>
       <button
-        className="fixed lg:hidden bottom-4 right-4 h-8 w-8 border border-neutral-200 rounded-full backdrop-blur-sm flex items-center justify-center"
+        className="fixed lg:hidden bottom-4 right-4 h-8 w-8 border border-neutral-200 rounded-full backdrop-blur-sm flex items-center justify-center z-10"
         onClick={() => setOpen(!open)}
       >
         <IconLayoutSidebarRightCollapse className="h-4 w-4 text-secondary" />


### PR DESCRIPTION
The sidebar button doesn't work when viewing the resume page on mobile.

Added a higher z-index to fix

Before:

https://github.com/manuarora700/sidefolio/assets/35680780/9b641fc1-dbdc-49c3-ac23-8426b3e41eda

After:

https://github.com/manuarora700/sidefolio/assets/35680780/280b4b03-31e0-46eb-8461-c22dce4b8dfb



